### PR TITLE
Delete ignored key from config.json

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,28 +9,26 @@
       "slug": "hello-world",
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
       "slug": "rna-transcription",
       "difficulty": 1,
       "topics": [
+
       ]
     },
     {
       "slug": "tautology",
       "difficulty": 1,
       "topics": [
+
       ]
     }
   ],
   "deprecated": [
 
-  ],
-  "ignored": [
-    "bin",
-    "img",
-    "docs"
   ],
   "foregone": [
 


### PR DESCRIPTION
Since the exercise implementations are all in the exercises directory
we no longer need to ignore any non-exercise directories in the root
of the track.

See https://github.com/exercism/meta/issues/3 for context.