### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Exercism Coq Track
 
-[![Build Status](https://travis-ci.org/exercism/xcoq.svg?branch=master)](https://travis-ci.org/exercism/xcoq)
+[![Build Status](https://travis-ci.org/exercism/coq.svg?branch=master)](https://travis-ci.org/exercism/coq)
 
 Exercism exercises in Coq.
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "coq",
   "language": "Coq",
-  "repository": "https://github.com/exercism/xcoq",
+  "repository": "https://github.com/exercism/coq",
   "active": false,
   "test_pattern": "TODO",
   "exercises": [

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -15,7 +15,7 @@ There is no additional testing step needed as we can offload all testing to the 
 
 ## Feedback, Issues, Pull Requests
 
-The [exercism/xcoq](https://github.com/exercism/xcoq) repository on
+The [exercism/coq](https://github.com/exercism/coq) repository on
 GitHub is the home for all of the Coq exercises.
 
 If you have feedback about an exercise, or want to help implementing a new


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1