### PR TITLE
Add default introductory code example

### DIFF
--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,0 +1,12 @@
+Require Import Coq.Strings.String.
+
+Open Scope string_scope.
+
+Definition hello:string := "Hello, World!".
+
+(* Unit test *)
+Lemma HelloTest:
+  hello = "Hello, World!" .
+Proof.
+  reflexivity.
+Qed.


### PR DESCRIPTION
Instead of having logic for a fallback in the backend, we're choosing a
default for the snippet file.

For tracks that have core exercises, we pick the first core exercise.
For tracks without these, we pick the first exercise listed in the config.

Note that we're aiming for 10 lines and a max-width of 40 columns.
This solution has 12 lines and a max-width of 43, so we may want to adjust it.

See https://github.com/exercism/meta/issues/89