### PR TITLE
Reformat config files

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,40 +1,32 @@
 {
   "language": "Coq",
   "active": false,
+  "blurb": "",
   "test_pattern": ".*[.]v",
   "exercises": [
     {
-      "uuid": "a001fd68-5913-4041-80ea-0558b269ba4f",
       "slug": "hello-world",
+      "uuid": "a001fd68-5913-4041-80ea-0558b269ba4f",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": [
-
-      ]
+      "topics": []
     },
     {
-      "uuid": "10a7ad13-8564-4713-853b-5b13a829ac50",
       "slug": "rna-transcription",
+      "uuid": "10a7ad13-8564-4713-853b-5b13a829ac50",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": [
-
-      ]
+      "topics": []
     },
     {
-      "uuid": "b647eb59-40ce-49c9-b0ce-775615ce0063",
       "slug": "tautology",
+      "uuid": "b647eb59-40ce-49c9-b0ce-775615ce0063",
       "core": false,
       "unlocked_by": null,
       "difficulty": 1,
-      "topics": [
-
-      ]
+      "topics": []
     }
-  ],
-  "foregone": [
-
   ]
 }

--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -1,15 +1,15 @@
 {
+  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md",
   "maintainers": [
     {
       "github_username": "proger",
-      "show_on_website": false,
       "alumnus": false,
+      "show_on_website": false,
       "name": null,
-      "bio": null,
       "link_text": null,
       "link_url": null,
-      "avatar_url": null
+      "avatar_url": null,
+      "bio": null
     }
-  ],
-  "docs_url": "https://github.com/exercism/docs/blob/master/maintaining-a-track/maintainer-configuration.md"
+  ]
 }


### PR DESCRIPTION
This runs the configlet fmt command, which normalizes the
contents and ordering of keys in the track config and
maintainers config.

This will let us script changes to the config files without
having unnecessary noise in the diffs when submitting pull
requests.

See exercism/meta#95