### PR TITLE
Update URL for Exercism Code of Conduct link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Recommended version of Coq: 8.6
 
 Thank you so much for contributing! :tada:
 
-Please read about how to [get involved in a track](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks). Be sure to read the Exercism [Code of Conduct](https://github.com/exercism/exercism.io/blob/master/CODE_OF_CONDUCT.md).
+Please read about how to [get involved in a track](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks). Be sure to read the Exercism [Code of Conduct](https://exercism.io/code-of-conduct).
 
 We welcome pull requests of all kinds. No contribution is too small.
 


### PR DESCRIPTION
See https://github.com/exercism/exercism/issues/4441.