### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,11 @@
+{
+  "docs": [
+    {
+      "uuid": "7eb8d3f5-ca64-4984-9bda-a1bea1ee498d",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Coq",
+      "blurb": "An overview of how to get started from scratch with Coq"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
