### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -9,7 +9,7 @@
   ],
   "files": {
     "solution": [
-      "hello-world.v"
+      "helloworld.v"
     ],
     "test": [
       "test.v"

--- a/exercises/practice/hello-world/helloworld.v
+++ b/exercises/practice/hello-world/helloworld.v
@@ -1,3 +1,5 @@
 Require Import Coq.Strings.String.
 
-Definition hello:string :=  (* add your definition here *).
+Open Scope string_scope.
+
+Definition hello:string := "Goodbye, Mars!".


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
